### PR TITLE
Simplify tupl assign helper

### DIFF
--- a/tupl_impl/tupl_impl_assign.hpp
+++ b/tupl_impl/tupl_impl_assign.hpp
@@ -51,13 +51,9 @@ struct assign_to<Lr>
     enum:bool{ X = types_all<is_lval_nothrow_assignable,L,tupl_t<R>> };
     if constexpr (tupl_tie<L>)
       // copy or move assign according to RHS element reference types
-      [&]<template<typename...>class W
-         ,typename...U>(W<U...>const& r) noexcept(X)
-      {
-        map(r, [&](auto&...u) noexcept(X) {
-          assign_elements(l, (U)u...);
-        });
-      }(static_cast<tupl_t<R>const&>(r));
+      map(as_tupl_t(r), [&](auto&&...u) noexcept(X) {
+        assign_elements(l, (decltype(u))u...);
+      });
     else
       // copy or move assign all elements decided by RHS reference type
       map(as_tupl_t((R&&)r), [&](auto&&...u) noexcept(X)


### PR DESCRIPTION
Remove an unneccessary level of tupl type decomposition
which was using a template lambda specialization.

The map(lv,[&](auto&&...u)) extracted arguments u...
are member lookup expressions for which decltype(u)
on an lvalue tupl lv give the declared member type
already, so the decomposition was gratuitous.
