### PR TITLE
Fix trivial-copyability of ties, make tie non-const

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -621,35 +621,26 @@ This prints the nested tupl return value as `{{4,5,6},true}`
 
 * **`ties<Xs...>` : `tupl<Xs...>`** $+$ `operator=`
 
-The use case is reference-tuples.  
+The use case is as a tuple-of-references specialized for assignments.
+
 Tuples of references are used for:
 
-* Grouped, simultaneous assignment to multiple variables.
-* Forwarding of argument lists to functions.
-* Lexicographic comparison of lists of variables  
-(better handled by `cmps`).
+1. 'Collective assignment' to multiple variables.
+2. Forwarding of argument lists to functions.
+3. Lexicographic comparison of lists of variables.
 
-`ties` are trivially copyable so they can be cheap to pass around.
+In this library, each use case is best served by a specialized tupl-derived type.  
+(2.) is better handled by the `fwds` type
+(c.f.
+[`std::forward_as_tuple`](https://en.cppreference.com/w/cpp/utility/tuple/forward_as_tuple)).  
+(3.) is better handled by the`cmps` type
 
 A `tie` 'maker function' is the preferred way to make `ties`:
 
-* `tie(xs...)` $\rightarrow$ `ties<decltype(xs)&...> const`
+* `tie(xs...)` $\rightarrow$ `ties<decltype(xs)&...>`
 
 `tie` accepts only lvalues and deduces lvalues as assignment targets  
-and returns a const-qualified `ties`.
-
-`tie_fwd` forwards its `auto&&` arguments as lvalues or rvalues:
-
-* `tie_fwd(xs...)` $\rightarrow$ `ties<decltype(xs)...> const`
-
-(similar to
-[`std::forward_as_tuple`](https://en.cppreference.com/w/cpp/utility/tuple/forward_as_tuple)).
-
-### Why `const` ?
-
-The const qualifier removes the deleted default assignment operators from  
-consideration. The resulting const-qualified type satisfies *const-assignable*  
-concept, identifying it as an 'assign-through' reference type.
+and returns a `ties` tupl of lvalue references to its arguments.
 
 ----
 
@@ -689,11 +680,11 @@ However, it only handles all-move or all-copy assignments, not a mix.
 `ties` also admits assignments from other tuplish types:
 
 ```c++
-  lml::tie(cp,mv) = tie_fwd(cc, std::move(mm));
+  lml::tie(cp,mv) = lml::fwds{cc, std::move(mm)};
 ```
 
 Here, copy and move assignments are mixed by assigning from a  
-forwarding tuple that ties both lvalue and rvalue references.
+forwarding tuple that binds both lvalue and rvalue references.
 
 ----
 

--- a/tests/tupl_test.cpp
+++ b/tests/tupl_test.cpp
@@ -191,12 +191,12 @@ using is_structural = structural<tupl{"tupl"}>;
 template <auto> using isstructural = std::true_type;
 static_assert(        isstructural< Tup{} >() );
 
-using tupl_scalar_refs = ties<int&, long&, char&>;
+using ties_scalar_refs = ties<int&, long&, char&>;
 
-static_assert( std::is_aggregate<tupl_scalar_refs>() );
-static_assert( std::is_trivially_copyable<tupl_scalar_refs>{});
-static_assert(!std::is_trivially_default_constructible<tupl_scalar_refs>());
-static_assert( MSVC(!) std::is_trivial_v<tupl_scalar_refs>);
+static_assert( std::is_aggregate<ties_scalar_refs>() );
+static_assert( ! std::is_trivially_copyable<ties_scalar_refs>{});
+static_assert( ! std::is_trivially_default_constructible<ties_scalar_refs>());
+static_assert( ! std::is_trivial_v<ties_scalar_refs>);
 
 #include <memory>
 #include <tupl/tupl_vals.hpp>
@@ -269,7 +269,7 @@ int main()
 
   vals<char[4],int> cppval; // uninitialized
   cppval = {cpp, std};      // two-phase init
-  cppval = lml::tie_fwd(cpp,'\x14');
+  cppval = lml::fwds{cpp,'\x14'};
 
   // two-phase init one-liner
   auto cppass = vals<char[4],int>{} = {cpp,std};

--- a/tupl/tupl_platform.hpp
+++ b/tupl/tupl_platform.hpp
@@ -50,6 +50,22 @@ static_assert(false,"[[no_unique_address]] attribute is required");
 #endif
 #endif
 
+// Supress warning on deprecated implicitly-declared copy operator
+// deliberate in ties as ah aggregate but non-trivially-copyable type
+//
+#ifndef START_NO_WARN_DEPRECATED_COPY
+# if defined(__GNUC__)
+#  define START_NO_WARN_DEPRECATED_COPY()\
+_Pragma("GCC diagnostic push")\
+_Pragma("GCC diagnostic ignored \"-Wdeprecated-copy\"")
+#  define END_NO_WARN_DEPRECATED_COPY()\
+_Pragma("GCC diagnostic pop")
+# else
+#  define START_NO_WARN_DEPRECATED_COPY()
+#  define END_NO_WARN_DEPRECATED_COPY()
+# endif
+#endif
+
 // Supress noisy missing-braces warnings on Clang
 //
 #ifndef NO_WARN_MISSING_BRACES

--- a/tupl/tupl_tie.hpp
+++ b/tupl/tupl_tie.hpp
@@ -11,73 +11,165 @@
 #include "namespace.hpp"
 
 /*
-  ties<E...> derives from tupl<E...> and adds operator=(rhs) overloads
+  ties<E...> : tupl<E...>
+  ==========
+  'ties' is a tupl-derived type for performing 'collective assignments'.
+  It is used as a reference-wrapper type, with reference semantics -
+  it is not intended to be used as a value type with value semantics.
 
-  1  operator=(same_ish<ties>) Replaces deleted default assignments
-                               (the only non-const qualified operator=)
-  2  operator=(tuplish) const  move or copy assigns from other tuplish
+  It is used as a temporary, transient, 'assignment wrapper' on the LHS
+  of '=' assignment ops from a tupl or braced-list of values on the RHS.
+
+  Non-transient use is often problematic so is not recommended
+  (language references prohibit array storage to avoid problems).
+
+  lml::ties is not trivially copyable, but remains an aggregate type.
+
+  lml::tie(a,b) -> lml::ties<A&,B&>{a,b}
+  =============
+  The tie function returns a ties-tupl of references to its arguments.
+  Use it on the LHS of assignments:
+
+    int a;
+    std::string b, c="two";
+    lml::tie(a,b) = {};
+    lml::tie(a,b) = {1,"one"};
+    lml::tie(a,b) = {2,std::move(c)};
+
+  This enforces transient use following an idiom set by std::tie.
+
+  Comparison to std::tie
+  ======================
+  The std <tuple> function std::tie does not accept braced list RHS.
+  It returns a std::tuple of references for assign-through from a
+  std::tuple of source values; std::tie(a,b) = std::tuple{2,"two"}.
+
+  The ties type accepts braced list RHS in order to mimic the syntax
+  that works for value tupls as aggregate types. However, assignment
+  from braced lists only performs all-copy or all-move assignments.
+  Mixed assignments require a tupl RHS of mixed lvalues and rvalues.
+
+  std::tuple assignments return an lvalue reference to *this.
+  lml::ties assignments return void to prevent chained assignments.
+
+  std::tie supports all std::tuple heterogeneous comparisons.
+  lml::ties are only same-type comparable (heterogeneous comparison
+  is provided by the 'cmps' tupl-derived 'comparison wrapper' type).
+
+  getie<I...>(tuplish) -> lml::ties{get<I>(tuplish)...}
+  ====================
+  The getie function returns a ties-tupl of references to explicitly
+  indexed elements of its tuplish argument.
+
+
+  *****************************************************************
+  ties assignment operator= overloads
+  ===================================
+
+  Six operator=(rhs) overloads help mimic tuple-of-value assignments.
+  All apart from 1a are const qualified and require tupl_tie<ties>
+
+  1a operator=(ties)           copy-assign for tupl-of-values =default
+  1b operator=(ties) const     copy-assign for tupl-of-refs
+
+  2  operator=(tuplish) const  move or copy-assign from other tuplish
+                               based on ref quals of RHS types
+
   3a operator=({rvals}) const  move-assigns from init-list of rvalues
   3b operator=({lvals}) const  copy-assigns from init-list of lvalues
-  4  operator=({}) const       assign from empty init list, i.e. 'clear'
+
+  4  operator=({}) const       assign from empty init list
+                               i.e. 'clear' all elements
+
+  Only overload 2 can perform mixed copy or move assignments but it
+  cannot accept braced init-list RHS (because it deduces its type).
+  Overloads 3a & 3b perform all move or all copy from braced init-lists
+  with moves preferred if all initializers are rvalues.
 */
+
+START_NO_WARN_DEPRECATED_COPY()
+
 template <typename...E> struct ties : tupl<E...>
 {
-  // assign ties = ties replaces deleted default assign, non-const
-  template <same_ish<ties> Ties>
-  constexpr auto& operator=(Ties&& r)
-    noexcept(noexcept(assign_to{*this} = r))
-    requires tupl_tie<ties>
-  { return assign_to{*this} = r; }
+  // copy-assign for value tuples default delegates to base operator=
+  ties& operator=(ties const& r) requires tupl_val<ties> = default;
 
-  // assign ties = tuplish, allowing only non-narrowing conversions
+  // copy-assign ties = ties replaces deleted default assign
+  constexpr void operator=(ties const& r) const
+    noexcept(noexcept(assign_from(r)))
+    requires tupl_tie<ties>
+  { assign_from(r); }
+
+  // assign ties = tuplish, allows non-narrowing conversions only
   template <tuplish T>
-  constexpr auto& operator=(T&& r) const
-    noexcept(noexcept(assign_to{*this} = r))
-    requires types_all<is_non_narrow_const_assignable,ties,tupl_t<T>>
-  { return assign_to{*this} = r; }
+  constexpr void operator=(T&& r) const
+    noexcept(noexcept(assign_from(r)))
+    requires (tupl_tie<ties>
+             && types_all<is_non_narrow_const_assignable,ties,tupl_t<T>>)
+  { assign_from(r); }
 
   // assign ties = tupl_move rvalue init list; move is better match
   template <typename...>
-  constexpr auto& operator=(tupl_move_t<ties> r) const
-    noexcept(noexcept(assign_to{*this} = r))
+  constexpr void operator=(tupl_move_t<ties> r) const
+    noexcept(noexcept(assign_from(r)))
     requires (tupl_tie<ties> && move_assignable<E...>)
-  { return assign_to{*this} = r; }
+  { assign_from(r); }
 
   // assign ties = tupl_view lvalue init list; copy is worse match
   template <typename A = tupl_view_t<ties>, typename B = A>
-  constexpr auto& operator=(A const& r) const
-    noexcept(noexcept(assign_to{*this} = r))
+  constexpr void operator=(A const& r) const
+    noexcept(noexcept(assign_from(r)))
     requires(std::same_as<A,B>&& tupl_tie<ties>&& copy_assignable<E...>)
-  { return assign_to{*this} = r; }
+  { assign_from(r); }
 
   // assign ties = {} empty list assignment
-  template<typename...>
-  constexpr auto& operator=(std::true_type) const
-    noexcept(noexcept(assign_to{*this} = std::true_type{}))
-    requires tupl_tie<ties>
-  { return assign_to{*this} = std::true_type{}; }
+  constexpr void operator=(std::true_type) const
+    noexcept(types_all<is_nothrow_empty_list_assignable,ties>)
+    requires (tupl_tie<ties> && types_all<is_empty_list_assignable,ties>)
+  {
+    map(as_tupl_t(*this),
+        [](auto&...t)
+          noexcept(types_all<is_nothrow_empty_list_assignable,ties>)
+        {
+          ((assign(t)={}),...);
+        });
+  }
+
+  // ties::assign_from(tuplish)
+  template <template<typename...>class Tupl, typename...U>
+  constexpr void assign_from(Tupl<U...> const& r) const
+    noexcept((is_nothrow_assignable_v<E&,U> && ...))
+    requires (tuplish<Tupl<U...>> && (is_assignable_v<E&,U> && ...))
+  {
+    map(as_tupl_t(r),
+        [this](auto&...u)
+          noexcept((is_nothrow_assignable_v<E&,U> && ...))
+        {
+          assign_elements(*this, static_cast<U>(u)...);
+        }
+       );
+  }
 };
 
-// ties CTAD, deduces forwarding references
+END_NO_WARN_DEPRECATED_COPY()
+
+// ties CTAD, deduces lvalue references
 //
-template <typename...E> ties(E&&...) ->  ties<E&&...>;
+template <typename...E> ties(E&...) -> ties<E&...>;
+
+// ties CTAD from tupl base class
+//
+template <typename...E> ties(tupl<E&...>) -> ties<E&...>;
 
 //
 // tie(a...) -> ties<decltype(a)&...>{a...}; rejects rvalue arguments
 //
 template <typename...T>
-constexpr auto tie(T&...t) noexcept -> ties<T&...> const
+constexpr auto tie(T&...t) noexcept -> ties<T&...>
 {
     return { t... };
 }
-//
-// tie_fwd(a...) -> ties<decltype(a)...>{a...} const
-//                     same as CTAD ties{a...} but const qualified
-template <typename...T>
-constexpr auto tie_fwd(T&&...t) noexcept -> ties<T&&...> const
-{
-    return { (T&&)t... };
-}
+
 //
 // getie<I...>(tupl) -> tie(get<I>(tupl)...)
 //

--- a/tupl_impl/tupl_impl.pp
+++ b/tupl_impl/tupl_impl.pp
@@ -110,7 +110,7 @@ template <typename...E> cvals(E const&...) -> cvals<tupl_view_t<E>...>;
 #define MAYBE_UNUSED0()
 #endif
 
-#define MEMBER_FWDS(t) XREPEAT(VREPEAT_INDEX,t.TUPL_DATA_ID,COMMA)
+#define  MEMBER_ACCESSES(t) XREPEAT(VREPEAT_INDEX,t.TUPL_DATA_ID,COMMA)
 
 //
 template <XREPEAT(VREPEAT_INDEX,class TUPL_TYPE_ID,COMMA)>
@@ -123,13 +123,13 @@ struct TUPL_ID<XREPEAT(VREPEAT_INDEX,TUPL_TYPE_ID,COMMA)>
  friend auto operator<=>(TUPL_ID const&,TUPL_ID const&)
   NZREPEAT(requires types_all<is_member_default_3way,TUPL_ID>)= default;
  //
- template <same_ish<TUPL_ID> T, typename F, typename U = T&&>
- friend constexpr decltype(auto) map(MAYBE_UNUSED0()T&& t, F f)noexcept(
-  noexcept(f(MEMBER_FWDS(U(t)))))
-  { return f(MEMBER_FWDS(U(t))); }
+ template <same_ish<TUPL_ID> T, typename F>
+ friend constexpr decltype(auto) map(MAYBE_UNUSED0()T& t, F f)noexcept(
+  noexcept(f( MEMBER_ACCESSES(t))))
+  { return f( MEMBER_ACCESSES(t)); }
 };
 
-#undef MEMBER_FWDS
+#undef  MEMBER_ACCESSES
 #undef MAYBE_UNUSED0
 #undef NZREPEAT
 

--- a/tupl_impl/tupl_impl_assign.hpp
+++ b/tupl_impl/tupl_impl_assign.hpp
@@ -17,8 +17,8 @@ constexpr auto&& assign_elements(L&& l, T&&...v)
   swap(ta,tb) tupl swap specialization, includes const-assignable,
              (std::swap already handles possibly-nested C array)
 */
-template <tuplish L>
-constexpr void swap(L& l, L& r)
+template <tuplish L, same_ish<std::remove_cvref_t<L>> R>
+constexpr void swap(L&& l, R&& r)
   noexcept(types_all<std::is_nothrow_swappable, tupl_t<L>>)
   requires types_all<std::is_swappable, tupl_t<L>>
 {
@@ -60,7 +60,7 @@ struct assign_to<Lr>
       }(static_cast<tupl_t<R>const&>(r));
     else
       // copy or move assign all elements decided by RHS reference type
-      map(as_tupl_t((R&&)r), [&](auto&&...u) noexcept(X)
+      map(as_tupl_t(r), [&](auto&&...u) noexcept(X)
       {
           assign_elements(l, (decltype(u))(u)...);
       });
@@ -87,7 +87,7 @@ struct assign_to<Lr>
     noexcept(types_all<is_lval_nothrow_assignable,L,tupl_t<R>>)
     requires types_all<is_lval_assignable,L,tupl_t<R>>
   {
-    return assign_from((R&&)r);
+    return assign_from(r);
   }
 
   // move assign from braced init-list of rvalues; better match


### PR DESCRIPTION
lml::ties reference tuple type was incorrectly trivially copyable.
lml::tie(a...) function returned a const-qualified ties

This PR makes ties non-trivially-copyable and tie result non-const
then deals with consequences and also starts to remove reliance on
the nested generic assignment implementation ready to remove it.

readme.md

  * Doc: Update with PR changes

tupl/tupl_tie.hpp

  * Doc: Add top doc with rationale.
  * Doc: update operator= summary.

  ties class:
  * Replace templated copy/move assignment operator= with:
     * a defaulted copy-assignment operator= for value types
     * a custom copy-assignment operator= for reference types

     * as a consequence ties becomes non trivially-copyable
     * ties containing rvalue references are not copy constructible
       (ties is not intended to hold rvalue references)

  * Update all assignment operator= overloads:
     * return void rather than ties& to prevent chained assignments
     * delegate to new member function assign_from(r)

  * Add new member function assign_from(r)
    delegating via map(*this,...) to assign_elements(*this,u...)

  * Implement empty-brace assignment operator= inline

  * Add _NO_WARN_DEPRECATED_COPY macros to supress bogus warning

  tie(auto&...) function:
  - Remove const qualification on the return type
    (previously used for operator= overload disambiguation)

  tie_fwd(auto&&...) function:
  - Remove tie_fwd, intended to provide an RHS assignment source type
    like std::forward_as_tuple it does not belong alongside ties as a
    LHS target for assignments.

  Making the ties type trivially-copyable was incorrect as algorithms
  may use memcpy on types that advertise trivial-copyability where a
  reference-semantic type should use a non-trivial assignment operator.

tupl/tupl_platform.hpp

  * Add _NO_WARN_DEPRECATED_COPY macros to supress warning on ties

tupl_impl/tupl_impl_assign.hpp

  * Update swap to accept non-const rvalues such as a tie return
    (is this now too lenient; constrain to reference-like types?)

  * Update generic assignment ops to not forward the tupl type.

tupl_impl/tupl_impl.pp

  * Simplify tupl map to accept tupl as lvalue, and no forwarding.

tests/test.cpp
tests/tupl_test.cpp

  * Update and fix up tests for PR
