### PR TITLE
tupl cat and CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,6 @@ name: ci_meson
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - "**.cpp"
-      - "**.hpp"
   pull_request:
     paths:
       - "**.cpp"
@@ -49,11 +45,8 @@ jobs:
             cxx: cl
           }
     steps:
-    - uses: de-vri-es/setup-git-credentials@v2.0.10
-      with:
-        credentials: ${{secrets.GIT_CREDENTIALS}}
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - run: pip install meson ninja

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -552,6 +552,10 @@ bool test_refs()
 {
   int i, ii;
   ties<int>{1} = ties<int>{0};
+ // TODO this conditional triviallity test fails on clang 14
+# if not defined(__clang__)
+  static_assert( std::is_trivially_copyable_v<ties<int>> );
+# endif
   ties<int&>{i} = ties<int&>{ii};
 static_assert( std::is_trivially_copyable_v<ties<int&>> );
  const ties<int&> ti{ i };

--- a/tupl/tupl_platform.hpp
+++ b/tupl/tupl_platform.hpp
@@ -54,19 +54,21 @@ static_assert(false,"[[no_unique_address]] attribute is required");
 //
 #ifndef NO_WARN_MISSING_BRACES
 # if defined(__clang__)
-#  define NO_WARN_MISSING_BRACES(...)\
+#  define NO_WARN_MISSING_BRACES()\
 _Pragma("GCC diagnostic push")\
-_Pragma("GCC diagnostic ignored \"-Wmissing-braces\"")\
-__VA_ARGS__ \
+_Pragma("GCC diagnostic ignored \"-Wmissing-braces\"")
+#  define END_NO_WARN_MISSING_BRACES()\
 _Pragma("GCC diagnostic pop")
 # else
-#  define NO_WARN_MISSING_BRACES(...)__VA_ARGS__
+#  define NO_WARN_MISSING_BRACES()
+#  define END_NO_WARN_MISSING_BRACES()
 # endif
 #endif
 
 #else // UNDEFINE
 
 #undef NO_WARN_MISSING_BRACES
+#undef END_NO_WARN_MISSING_BRACES
 #undef TYPEPACKEL
 
 #undef NUA

--- a/tupl/tupl_traits.hpp
+++ b/tupl/tupl_traits.hpp
@@ -196,11 +196,11 @@ using tupl_fwd_t = typename tupl_fwd<t>::type;
 // Fails with a static_assert if there's no X or multiple Xs in E...
 //
 template <typename X, typename...E>
-inline constexpr int type_pack_indexof = [] {
+inline constexpr auto type_pack_indexof = [] {
   static_assert(sizeof...(E) > 0, "type_pack_indexof zero-size pack");
   static_assert((std::same_as<X,E> + ...) == 1,
     "type_pack_indexof error: pack must have a single matching type");
-  int r{};
+  std::size_t r{};
   return (..., (r += r || std::same_as<X,E>)), sizeof...(E) - r;
 }();
 

--- a/tupl_impl/tupl_impl.pp
+++ b/tupl_impl/tupl_impl.pp
@@ -153,9 +153,9 @@ constexpr auto get(T&& t) noexcept
   return map(static_cast<tupl_like_t<T>&>(t), [](auto&...a) noexcept
     -> ret_t
   {
-    NO_WARN_MISSING_BRACES(
+    NO_WARN_MISSING_BRACES()
       return static_cast<ret_t>(*At{0,&a...,0}.e);
-    )
+    END_NO_WARN_MISSING_BRACES()
   });
 }
 


### PR DESCRIPTION
tupl/tupl_cat.hpp:
 * Specify only the outer function return type leaving the lambda.

   clang14 ICEs when inner lambda has explicit trailing return.
   It accepts the outer function explicit return type.

   MSVC without explicit return types gives error C3546:
   '...': there are no parameter packs available to expand.
   It is confused by the double pack expansion.
   Add tupl cat_elem_t alias template pack helper to fix this.

ci.yml:
   CI remove trigger on pull_request and bump deps.

tupl/tupl_traits.hpp:
   Fix int sign mismatch

tests/test.cpp
   ifdef out clang fail
