### PR TITLE
Update vals in line with ties and simplify

### DIFF
--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -480,7 +480,7 @@ void tupl_tie_assign()
 
   // initialize an array value member from an array lvalue
   constexpr int ca2[2]{1,2};
-  constexpr auto arrayinit = tupl(vals<int[2]>{} = {ca2});
+  constexpr auto arrayinit = tupl_init(ca2);
   static_assert( arrayinit == tupl<int[2]>{{1,2}} );
 
   static int ops[16]{};
@@ -851,9 +851,6 @@ void tupl_cats()
 
   auto tuplstref =tupl<C&>{str};
   [[maybe_unused]]tupl<C&> tuplstref2(tuplstref);
-
-  ties tt{tuplstref};
-  SAME( decltype(tt), ties< C& > );
 
   auto ttt = cat<fwds>(tupl{"str"});
   SAME( decltype(ttt), fwds< C&& > );

--- a/tupl/tupl_traits.hpp
+++ b/tupl/tupl_traits.hpp
@@ -93,14 +93,6 @@ template <template <typename...> class L, typename...T,
   requires (sizeof...(T) == sizeof...(U))
 inline constexpr bool types_all<P,L<T...>,R<U...>> = (P<T,U>() && ...);
 
-//static_assert(types_all<std::is_fundamental, int>);
-
-template <typename...E>
-concept move_assignable = (is_move_assignable_v<E> && ...);
-
-template <typename...E>
-concept copy_assignable = (is_copy_assignable_v<E> && ...);
-
 template <typename L, typename R>
 using is_lval_assignable = is_assignable<L&,R>;
 

--- a/tupl/tupl_vals.hpp
+++ b/tupl/tupl_vals.hpp
@@ -11,36 +11,73 @@
 #include "namespace.hpp"
 
 /*
-  vals<E...> derives from tupl<E...> and adds operator= overloads
+  vals<E...> : tupl<E...>
+  ==========
+  'vals' is a tupl-derived type that adds custom operator= overloads
+  to deal with two assignability shortcomings of the base tupl:
 
-  1  operator=(tuplish); Non-narrowing copy-conversions from other tupl
+    1. A tupl is assignable only from a same-type tupl on the RHS.
+       Ability to assign from a tupl of forwarding references helps
+       eliminate redundant copies implicit in 'aggregate assignment'.
+
+    2. C array variables don't initialize or assign from array values
+       so attempts to assign tupl C array elements from array values
+       listed in a braced init-list RHS fails at the first step.
+
+  Overload #1 provides 'heterogeneous' assignment from tuplish types
+  of assignable-from element types, including references.
+
+  Overloads #2a,2b handle 'braced init-list' assignments to C arrays.
+
+  1  operator=(tuplish) move or copy-assign elements from other tuplish
+                        based on the value category of RHS element types
+                        allows non-narrowing conversions only.
+                        RHS is deduced so cannot be a braced init-list.
+
   2a operator=({rvals}); move-assigns from braced init-list of rvalues
   2b operator=({lvals}); copy-assigns from braced init-list of lvalues
 */
+
 template <typename...E> struct vals : tupl<E...>
 {
-  // assign vals = tuplish, allowing only non-narrowing conversions
+  // assign vals = tuplish, allows non-narrowing conversions only
   template <tuplish T>
-  constexpr auto& operator=(T&& r)
-    noexcept(noexcept(assign_to{*this} = (T&&)r))
+  constexpr void operator=(T&& r)
+    noexcept(noexcept(assign_from(r)))
     requires (types_all<is_non_narrow_assignable,vals,tupl_t<T>>)
-  { return assign_to{*this} = (T&&)r; }
+  { assign_from(r); }
 
-  // assign vals = tupl_move rvalue init list; move is better match
+  // assign vals = tupl_move, from init-list of rvalues; move is better match
   template <typename...>
-  constexpr auto& operator=(tupl_move_t<vals> r)
-    noexcept(noexcept(assign_to{*this} = (decltype(r)&&)r))
-    requires move_assignable<E...>
-  { return assign_to{*this} = (decltype(r)&&)r; }
+  constexpr void operator=(tupl_move_t<vals> r)
+    noexcept(noexcept(assign_from(r)))
+    requires (is_move_assignable_v<E> && ...)
+    { assign_from(r); }
 
-  // assign tupl_val = tupl_view lvalue init list; copy is worse match
+  // assign vals = tupl_view, from init-list of lvalues; copy is worse match
   template <typename A = tupl_view_t<vals>, typename B = A>
-  constexpr auto& operator=(B r)
-    noexcept(noexcept(assign_to{*this} = r))
-    requires (std::same_as<A,B> && copy_assignable<E...>)
-  { return assign_to{*this} = r; }
+  constexpr void operator=(B r)
+    noexcept(noexcept(assign_from(r)))
+    requires (std::same_as<A,B> // tie break against tupl_move_t
+              && (is_copy_assignable_v<E> && ...))
+  { assign_from(r); }
+
+  // vals::assign_from(tuplish)
+  template <template<typename...>class Tupl, typename...U>
+  constexpr void assign_from(Tupl<U...> const& r)
+    noexcept((is_nothrow_assignable_v<E&,U> && ...))
+    requires (tuplish<Tupl<U...>> && (is_assignable_v<E&,U> && ...))
+  {
+    map(as_tupl_t(r),
+        [this](auto&...u) noexcept((is_nothrow_assignable_v<E&,U> && ...))
+        {
+          assign_elements(*this, static_cast<U>(u)...);
+        }
+       );
+  }
 };
-// vals CTAD
+
+// vals CTAD, deduce all by-value including arrays with no decay
 //
 template <typename...E> vals(E const&...) -> vals<E...>;
 


### PR DESCRIPTION
tupl/tupl_tie.hpp
 * Inline docs improvements
 * Remove converting deduction guide
 * Add geties function
 * Remove getie const-qualified return

tupl/tupl_vals.hpp
 * Inline docs similar to tupl_tie
 * Change operator= return types to void
 * Add assign_from helper and use it in place of generic assign_to
 * Remove use of variadic concepts copy_ and move_assignable

tupl/tupl_traits.hpp
 * Remove variadic concepts copy_ and move_assignable

tests/test.cpp
tests/tupl_test.cpp
 * Update tests in line with changes
